### PR TITLE
Add Scala Code of Conduct

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,12 @@
+# Code of Conduct
+
+We are committed to providing a friendly, safe and welcoming environment for all, regardless of level of experience, gender, gender identity and expression, sexual orientation, disability, personal appearance, body size, race, ethnicity, age, religion, nationality, or other such characteristics.
+
+Everyone is expected to follow the [Scala Code of Conduct] when discussing the project on the available communication channels. If you are being harassed, please contact us immediately so that we can support you.
+
+## Moderation
+
+For any questions, concerns, or moderation requests, please contact a member of the [community staff](https://http4s.org/code-of-conduct/#moderation)
+
+[Scala Code of Conduct]: https://http4s.org/code-of-conduct/
+[Community staff]: https://http4s.org/code-of-conduct/#moderation


### PR DESCRIPTION
All the Typelevel projects have this, and it integrates with GitHub's community insights.